### PR TITLE
fix: Correct error message assertion in telegramAuth test

### DIFF
--- a/src/auth/telegramAuth.test.ts
+++ b/src/auth/telegramAuth.test.ts
@@ -112,9 +112,9 @@ describe('TelegramAuth', () => {
 
     it('should handle malformed init data', () => {
       const result = telegramAuth.validateInitData('invalid_init_data');
-      
+
       expect(result.valid).toBe(false);
-      expect(result.error).toBe('Failed to validate init data');
+      expect(result.error).toBe('No hash provided');
     });
   });
 


### PR DESCRIPTION
## Summary
- telegramAuth.test.ts の失敗していたテストを修正
- エラーメッセージのアサーションを実装に合わせて修正

## 問題
Issue #3: telegramAuth.test.ts:117 でテストが失敗していました。

```
Expected: "Failed to validate init data"
Received: "No hash provided"
```

## 原因
`validateInitData('invalid_init_data')` を呼び出すと、hashパラメータがないため、実装コードの24行目で `"No hash provided"` を返します。テストの期待値が間違っていました。

## 修正内容
- テストの期待値を `"No hash provided"` に修正

## テスト結果
✅ 全テスト 37/37 PASS  
✅ Auth module カバレッジ: 97.95%  
✅ TypeScriptエラー: 0件（このファイルに関して）

## Closes
Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)