### PR TITLE
fix: Add .js extensions to ES Module imports and fix __dirname

### DIFF
--- a/src/auth/telegramAuth.ts
+++ b/src/auth/telegramAuth.ts
@@ -3,7 +3,7 @@
  */
 
 import crypto from 'crypto';
-import { TelegramWebAppInitData, TelegramUser } from '../types';
+import { TelegramWebAppInitData, TelegramUser } from '../types/index.js';
 
 export class TelegramAuth {
   private botToken: string;

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -3,7 +3,7 @@
  */
 
 import sqlite3 from 'sqlite3';
-import { PlayerStats, GameState, DatabaseSchema } from '../types';
+import { PlayerStats, GameState, DatabaseSchema } from '../types/index.js';
 
 export class DatabaseManager {
   private db: sqlite3.Database;

--- a/src/game/gameLogic.ts
+++ b/src/game/gameLogic.ts
@@ -2,7 +2,7 @@
  * Tic-Tac-Toe game logic implementation
  */
 
-import { GameBoard, CellValue, GameResult, GameState, Player } from '../types';
+import { GameBoard, CellValue, GameResult, GameState, Player } from '../types/index.js';
 import { v4 as uuidv4 } from 'uuid';
 
 export class GameLogic {

--- a/src/game/gameManager.ts
+++ b/src/game/gameManager.ts
@@ -2,9 +2,9 @@
  * Game manager for handling rooms and matches
  */
 
-import { GameRoom, GameState, Player, TelegramUser } from '../types';
-import { GameLogic } from './gameLogic';
-import { DatabaseManager } from '../database/database';
+import { GameRoom, GameState, Player, TelegramUser } from '../types/index.js';
+import { GameLogic } from './gameLogic.js';
+import { DatabaseManager } from '../database/database.js';
 import { v4 as uuidv4 } from 'uuid';
 
 export class GameManager {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,10 +7,16 @@ import { createServer } from 'http';
 import { Server } from 'socket.io';
 import cors from 'cors';
 import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 import { TelegramAuth } from './auth/telegramAuth.js';
 import { DatabaseManager } from './database/database.js';
 import { GameManager } from './game/gameManager.js';
 import { SocketEvents, TelegramUser, PlayerStats } from './types/index.js';
+
+// ES Modules compatibility
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const app = express();
 const server = createServer(app);


### PR DESCRIPTION
## Summary
ES Modules形式のインポートパスに `.js` 拡張子を追加し、`__dirname` のES Modules対応を実装してサーバー起動問題を解決しました。

## 問題
Issue #13: ES Modulesのインポートエラーによりサーバーが起動できない

### エラー内容
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../dist/game/gameLogic' imported from .../dist/game/gameManager.js
```

```
ReferenceError: __dirname is not defined in ES module scope
```

## 原因
1. `package.json` に `"type": "module"` が設定されている
2. TypeScriptコードで相対インポート時に `.js` 拡張子を明示していない
3. ES Modulesでは `__dirname` がグローバルに定義されていない

## 修正内容

### 1. インポートパスの修正
以下のファイルで相対インポートに `.js` 拡張子を追加:
- `src/auth/telegramAuth.ts` (`../types` → `../types/index.js`)
- `src/database/database.ts` (`../types` → `../types/index.js`)
- `src/game/gameLogic.ts` (`../types` → `../types/index.js`)
- `src/game/gameManager.ts` (3箇所のインポートパス修正)
  - `../types` → `../types/index.js`
  - `./gameLogic` → `./gameLogic.js`
  - `../database/database` → `../database/database.js`

### 2. `__dirname` のES Modules対応
`src/server.ts` に以下を追加:
```typescript
import { fileURLToPath } from 'url';
import { dirname } from 'path';

const __filename = fileURLToPath(import.meta.url);
const __dirname = dirname(__filename);
```

## 動作確認

✅ **成功**:
- TypeScriptコンパイル成功
- サーバー起動成功 (port 3001で確認)
- モジュール解決エラー 0件

⚠️ **既知の課題**:
- Jestの設定が `.js` 拡張子付きインポートに対応していない
- テスト実行時にモジュール解決エラーが発生
- → 別Issueで対応予定

## テスト結果
```bash
$ npm run build
> tsc
✅ ビルド成功

$ node dist/server.js
Server running on port 3001
✅ サーバー起動成功
```

## 影響範囲
- 実装ファイル5つ修正
- テストファイルは未修正（Jest設定の課題あり）
- 本番ビルド・起動には影響なし

## 次のステップ
Issue #13 解決後、以下を実施可能:
- Issue #5: Telegram Bot設定
- Issue #4: 本番デプロイ

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)